### PR TITLE
Restore comma- and whitespace-tolerant input parsing (CSV support)

### DIFF
--- a/base/util.c
+++ b/base/util.c
@@ -106,7 +106,7 @@ static size_t wordcount(FILE *fp, int linecapa){
   fseek(fp,0,SEEK_SET);
   fgets(line,linecapa,fp); len=strlen(line);
   fseek(fp,0,SEEK_SET);
-  while(fscanf(fp,"%lf",&num)){if(ftell(fp)>=len){break;}ct++;}
+  while(fscanf(fp,"%lf",&num)==1){if(ftell(fp)>=len){break;}ct++;fscanf(fp,"%*[, \t\r]");}
   free(line);
   return ct;
 }
@@ -128,11 +128,9 @@ double *read2dcm(int *nr, int *nc, const char *filename){
   r=linecount(fp,capa); n=r*c;
   a=(double*) malloc(n*sd);
 
-  switch(c){
-    case 2:  for(i=0;i<r;i++) fscanf(fp,"%lf%lf",   a+c*i,a+c*i+1);          break;
-    case 3:  for(i=0;i<r;i++) fscanf(fp,"%lf%lf%lf",a+c*i,a+c*i+1,a+c*i+2);  break;
-    default: for(i=0;i<n;i++) fscanf(fp,"%lf",a+i);
-  } *nr=r; *nc=c; fclose(fp);
+  /* Separator-tolerant read: accepts comma-, space-, and tab-delimited files. */
+  for(i=0;i<n;i++){fscanf(fp,"%*[, \t\r\n]");fscanf(fp,"%lf",a+i);}
+  *nr=r; *nc=c; fclose(fp);
 
   return a;
   err01: fprintf(stderr,"\n\n  File '%s': Not Found.\n\n",filename); exit(EXIT_FAILURE);


### PR DESCRIPTION
### Summary

The matrix reader introduced in `616b4c5` ("major update", Mar 2025) parses input with `fscanf(fp, "%lf", ...)`, which stops at commas. As a result, **comma-delimited input files are read as a single column**: an `N × D` point set is interpreted as `N × 1`.

The previous reader (`read2d`) used a delimiter set of `",\t\n"`, so comma-, tab-, and space-separated files all worked. The current `read2dcm` only handles whitespace/tab.

### Impact

This is a silent behavioral regression:

- Comma-delimited point sets parse as `[N, 1]` instead of `[N, D]`.
- Downstream the computation degenerates rather than reporting a format error — e.g. `ERROR: The Cholesky factorization of A failed at the update of v`.
- The whitespace-only requirement isn't documented in the README "Input data" section or in the `-v` help text.

This surfaced in [SlicerMorph](https://github.com/SlicerMorph/SlicerMorph)'s ALPACA module, which writes comma-delimited point sets and worked with older bcpd (e.g. v0.87) but fails with current `master`.

### Change

Make `read2dcm()` accept comma, space, and tab separators again, without changing behavior for whitespace-delimited files:

- `wordcount()`: consume trailing separators after each value so the column count is correct for comma-delimited lines.
- `read2dcm()`: read values with a separator-skipping scanset (`%*[, \t\r\n]`) instead of the fixed 2-/3-column `fscanf` formats.

4 insertions, 6 deletions in `base/util.c`.

### Testing

Built on macOS (Apple Silicon, clang + libomp + OpenBLAS). Using the same `N × 3` point sets saved both comma- and tab-delimited:

- Both now parse as `[N, 3]` and run to convergence (previously the comma version failed at the Cholesky step).
- The two outputs differ only at the level of the randomized Nyström/kd-tree acceleration (max ~0.06 over a coordinate range of ~3.5–34, the same magnitude as two identical-input runs), i.e. the parsing is equivalent.